### PR TITLE
feat(deepstack_sdk): Option to log the video frame number

### DIFF
--- a/deepstack_sdk/detection.py
+++ b/deepstack_sdk/detection.py
@@ -1,7 +1,7 @@
 from PIL import Image
 import cv2 
 from .config import ServerConfig
-from .utils import cv2ToBytes, pilToBytes, printError
+from .utils import cv2ToBytes, pilToBytes, printError, frameTracker
 from .structs import DetectionResponse
 from .viz import drawResponse, saveResponse
 import requests
@@ -73,7 +73,8 @@ class Detection(object):
                                 output_font=cv2.FONT_HERSHEY_SIMPLEX,output_font_color=(0,146,224),
                                 draw_bounding_box=True,
                                 show_label=True,
-                                show_conf=True):
+                                show_conf=True,
+                                log=True):
         detections = {}
         video_input = cv2.VideoCapture(video)
         width  = video_input.get(3) 
@@ -97,6 +98,7 @@ class Detection(object):
             valid, frame = video_input.read()
             if valid:
                 frame_count = frame_count + 1
+                frameTracker(log, frame_count)
                 frame_data = cv2ToBytes(frame)
                 response = self.__process_image(frame_data, min_confidence)
                 data = None

--- a/deepstack_sdk/face.py
+++ b/deepstack_sdk/face.py
@@ -1,7 +1,7 @@
 from PIL import Image
 import cv2 
 from .config import ServerConfig
-from .utils import cv2ToBytes, pilToBytes, printError
+from .utils import cv2ToBytes, pilToBytes, printError, frameTracker
 from .structs import FaceDetectionResponse, FaceRecognitionResponse, FaceListResponse
 from .viz import drawResponse, saveResponse
 import requests
@@ -106,7 +106,9 @@ class Face(object):
         else:
             raise Exception("Unknown error : {} occured".format(response.status_code))
 
-    def detectFaceVideo(self,video,min_confidence=0.4,output=None,codec=cv2.VideoWriter_fourcc(*'mp4v'),fps=24,display=False,callback=None, continue_on_error=False,output_font=cv2.FONT_HERSHEY_SIMPLEX,output_font_color=(0,146,224)):
+    def detectFaceVideo(self,video,min_confidence=0.4,output=None,codec=cv2.VideoWriter_fourcc(*'mp4v'),
+                        fps=24,display=False,callback=None, continue_on_error=False,
+                        output_font=cv2.FONT_HERSHEY_SIMPLEX,output_font_color=(0,146,224), log=True):
         detections = {}
         video_input = cv2.VideoCapture(video)
         width  = video_input.get(3) 
@@ -130,6 +132,7 @@ class Face(object):
             valid, frame = video_input.read()
             if valid:
                 frame_count = frame_count + 1
+                frameTracker(log, frame_count)
                 frame_data = cv2ToBytes(frame)
                 response = self.__detect_face(frame_data, min_confidence)
                 data = None
@@ -181,7 +184,10 @@ class Face(object):
 
         return detections
 
-    def recognizeFaceVideo(self,video,min_confidence=0.7,output=None,codec=cv2.VideoWriter_fourcc(*'mp4v'),fps=24,display=False,callback=None, continue_on_error=False,output_font=cv2.FONT_HERSHEY_SIMPLEX,output_font_color=(0,146,224), draw_bounding_box=True, show_label=True, show_conf=True):
+    def recognizeFaceVideo(self,video,min_confidence=0.7,output=None,codec=cv2.VideoWriter_fourcc(*'mp4v'),
+                            fps=24,display=False,callback=None, continue_on_error=False,
+                            output_font=cv2.FONT_HERSHEY_SIMPLEX,output_font_color=(0,146,224), 
+                            draw_bounding_box=True, show_label=True, show_conf=True, log=True):
         detections = {}
         video_input = cv2.VideoCapture(video)
         width  = video_input.get(3) 
@@ -205,6 +211,7 @@ class Face(object):
             valid, frame = video_input.read()
             if valid:
                 frame_count = frame_count + 1
+                frameTracker(log, frame_count)
                 frame_data = cv2ToBytes(frame)
                 response = self.__recognize_face(frame_data, min_confidence)
                 data = None

--- a/deepstack_sdk/scene.py
+++ b/deepstack_sdk/scene.py
@@ -1,7 +1,7 @@
 from PIL import Image
 import cv2 
 from .config import ServerConfig
-from .utils import cv2ToBytes, pilToBytes, printError
+from .utils import cv2ToBytes, pilToBytes, printError, frameTracker
 from .structs import SceneResponse
 import requests
 import os
@@ -56,7 +56,10 @@ class SceneRecognition(object):
         else:
             raise Exception("Unknown error : {} occured".format(response.status_code))
 
-    def recognizeSceneVideo(self,video,output=None,codec=cv2.VideoWriter_fourcc(*'mp4v'),fps=24,display=False,callback=None, continue_on_error=False, output_font=cv2.FONT_HERSHEY_SIMPLEX, output_font_color=(0,146,224)):
+    def recognizeSceneVideo(self,video,output=None,codec=cv2.VideoWriter_fourcc(*'mp4v'),
+                            fps=24,display=False,callback=None, continue_on_error=False, 
+                            output_font=cv2.FONT_HERSHEY_SIMPLEX, output_font_color=(0,146,224),
+                            log=True):
         detections = {}
         video_input = cv2.VideoCapture(video)
         width  = video_input.get(3) 
@@ -80,6 +83,7 @@ class SceneRecognition(object):
             valid, frame = video_input.read()
             if valid:
                 frame_count = frame_count + 1
+                frameTracker(log, frame_count)
                 frame_data = cv2ToBytes(frame)
                 response = self.__process_image(frame_data)
                 data = None

--- a/deepstack_sdk/utils.py
+++ b/deepstack_sdk/utils.py
@@ -29,4 +29,4 @@ def bytestoCV2(image_data):
 
 def frameTracker(log, frame_count):
     if log:
-        print("Frame {} processed".format(frame_count))
+        print("Processing frame {}".format(frame_count))

--- a/deepstack_sdk/utils.py
+++ b/deepstack_sdk/utils.py
@@ -26,3 +26,7 @@ def bytesToPIL(image_data):
 def bytestoCV2(image_data):
     np_arr = numpy.asarray(bytearray(image_data),dtype=numpy.uint8)
     return cv2.imdecode(np_arr,cv2.IMREAD_COLOR)
+
+def frameTracker(log, frame_count):
+    if log:
+        print("Frame {} processed".format(frame_count))


### PR DESCRIPTION
The commit make it posible to print the frame of the video currently
been analyzed by deepstack. This feature was acheived by add a log
parameter of type boolean to all the video procession functions.